### PR TITLE
fix(FBSDK): pin version

### DIFF
--- a/scripts/getFacebookSDK.js
+++ b/scripts/getFacebookSDK.js
@@ -3,7 +3,7 @@ const downloadStatus = require('download-status')
 const pathExists = require('path-exists')
 
 const iOS = {
-  dl: 'https://origincache.facebook.com/developers/resources/?id=facebook-ios-sdk-current.zip',
+  dl: 'https://origincache.facebook.com/developers/resources/?id=FacebookSDKs-iOS-4.16.0.zip',
   dist: './iOS/Frameworks/FacebookSDK',
 }
 


### PR DESCRIPTION
## Overview

Our builds are not compatible with the newest release of FBSDK, so we have to pin the version
## Reviewer
- [x] JS @timche 
- [x] iOS @Pho3nix 
